### PR TITLE
Optimized text for anvils and banner-writer link in /say

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ config.ini
 # info about user banners and user sets
 data.json
 
+# temporarily saved images
+temp/
+
 # local cache
 __pycache__/
 


### PR DESCRIPTION
When typing /say, it now provides:
1) An encoding of the text using the Banner resource pack which uses the minimum number of characters
Note: Any newlines in your message will just be converted to spaces since anvils don't allow spaces. This also means that vertical writing directions won't be supported here.
2) A link to edit the text in banner-writer.
Note: Banner writer only supports LTR and RTL writing directions.